### PR TITLE
updated installation instruction commands for cfdem

### DIFF
--- a/doc/_build/html/CFDEMcoupling_Manual.html
+++ b/doc/_build/html/CFDEMcoupling_Manual.html
@@ -359,8 +359,8 @@ cfdemSysTest
 <p>As step by step compilation of only specific parts, the following commands are available:</p>
 <div class="highlight-python"><div class="highlight"><pre><span class="n">cfdemCompLIG</span>
 <span class="n">cfdemCompCFDEMsrc</span>
-<span class="n">cfdemCompCFDEmsol</span>
-<span class="n">cfdenCompCFDEMuti</span>
+<span class="n">cfdemCompCFDEMsol</span>
+<span class="n">cfdemCompCFDEMuti</span>
 </pre></div>
 </div>
 <p>The compilation is automatically logged and the logs can be found in:</p>


### PR DESCRIPTION
Coupling commands for cfdem installation were incorrect due to typo in the documentation.